### PR TITLE
updated pellets to regenerate over time

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 
 public class GameManager : MonoBehaviour
@@ -96,7 +97,7 @@ public class GameManager : MonoBehaviour
 
     public void PelletEaten(Pellet pellet)
     {
-        pellet.gameObject.SetActive(false);
+        pellet.StartRegenerateTimeout();
         SetScore(this.score + pellet.points);
         lightCircle.Grow();
         if(!HasRemainingPellets())

--- a/Assets/Scripts/Pellet.cs
+++ b/Assets/Scripts/Pellet.cs
@@ -1,10 +1,15 @@
+using System;
+using System.Security.Cryptography;
 using UnityEngine;
 
 public class Pellet : MonoBehaviour
 {
     public int points = 10;
+    private float minRegenTime = 15; //Tune
+    private float maxRegenTime = 200; //Tune
     protected virtual void Eat()
     {
+        gameObject.SetActive(false);
         GameManager.Instance.PelletEaten(this);
     }
     private void OnTriggerEnter2D(Collider2D other)
@@ -12,6 +17,16 @@ public class Pellet : MonoBehaviour
         if(other.gameObject.layer == LayerMask.NameToLayer("Pacman")) {
             Eat();
         }
+    }
+    public void StartRegenerateTimeout(){
+        Debug.Log(minRegenTime);
+        Debug.Log(maxRegenTime);
+        float regenTime = UnityEngine.Random.Range(minRegenTime, maxRegenTime);
+        Debug.Log(regenTime);
+        Invoke(nameof(Regenerate), regenTime);
+    }
+    private void Regenerate(){
+        gameObject.SetActive(true);
     }
 
 }

--- a/Assets/Scripts/PowerPellet.cs
+++ b/Assets/Scripts/PowerPellet.cs
@@ -5,6 +5,7 @@ public class PowerPellet : Pellet
     public float duration = 8.0f;
     protected override void Eat()
     {
+        gameObject.SetActive(false);
         GameManager.Instance.PowerPelletEaten(this);
     }
 }


### PR DESCRIPTION
After pellets are eaten a random timeout is set before the pellet regenerates. Currently I'm using a random number between 15 and 200 seconds and I think it feels pretty good. After playing for a couple minutes the maze becomes pretty sparsely filled with pellets to were it forces you to move around a lot looking for them but it's still enough to just keep your light going. 